### PR TITLE
Fix write_msa_biopython for Biopython >= 1.78

### DIFF
--- a/ccmpred/io/alignment.py
+++ b/ccmpred/io/alignment.py
@@ -78,7 +78,8 @@ def write_msa_biopython(f, msa, ids, format, is_indices=True, descriptions=None)
     msa = ["".join(chr(c) for c in row) for row in msa]
 
     records = [
-        SeqRecord(Seq(seq, Bio.Alphabet.IUPAC.protein), id=id, description=desc)
+        SeqRecord(Seq(seq), id=id, description=desc,
+                  annotations={"molecule_type": "protein"})
         for seq, id, desc in zip(msa, ids, descriptions)
     ]
 


### PR DESCRIPTION
`Bio.Alphabet` was removed from Biopython` in v1.78 (September 2020).  Here, I propose to update the code in `write_msa_biopython` according to the instructions in https://biopython.org/wiki/Alphabet